### PR TITLE
Remove Truffle-Contract and unnecessary abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ How does this differ from the official React Truffle Box?
 - **No ejection** required;
 - **React frontend** is located in its own separate folder (i.e. `/client`);
 - **Babel** is included so you can use ES6 module import statements;
+- Uses v1.0 beta version of Web3 with PromiEvents
+- Truffle-Contract is no longer a dependency
 
 If you have Truffle installed, run the following to get started (more detailed instructions below):
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How does this differ from the official React Truffle Box?
 - **No ejection** required;
 - **React frontend** is located in its own separate folder (i.e. `/client`);
 - **Babel** is included so you can use ES6 module import statements;
-- Uses v1.0 beta version of Web3 with PromiEvents
+- Uses **Web3 1.0 beta** with **PromiEvents**
 - Truffle-Contract is no longer a dependency
 
 If you have Truffle installed, run the following to get started (more detailed instructions below):

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,6 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-scripts": "1.1.4",
-    "truffle-contract": "^3.0.5",
     "web3": "^1.0.0-beta.34"
   },
   "scripts": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import getWeb3 from './utils/getWeb3'
-import getAccounts from './utils/getAccounts'
 import getContractInstance from './utils/getContractInstance'
 import contractDefinition from './contracts/SimpleStorage.json'
 
@@ -15,7 +14,7 @@ class App extends Component {
       const web3 = await getWeb3()
 
       // Use web3 to get the user's accounts.
-      const accounts = await getAccounts(web3)
+      const accounts = await web3.eth.getAccounts()
 
       // Get the contract instance by passing in web3 and the contract definition.
       const contract = await getContractInstance(web3, contractDefinition)
@@ -34,13 +33,13 @@ class App extends Component {
     const { accounts, contract } = this.state
 
     // Stores a given value, 5 by default.
-    await contract.set(5, { from: accounts[0] })
+    await contract.methods.set(5).send({ from: accounts[0] })
     
     // Get the value from the contract to prove it worked.
-    const response = await contract.get.call({ from: accounts[0] })
+    const response = await contract.methods.get().call({ from: accounts[0] })
 
     // Update state with the result.
-    this.setState({ storageValue: response.toNumber() })
+    this.setState({ storageValue: response })
   }
 
   render() {

--- a/client/src/utils/getAccounts.js
+++ b/client/src/utils/getAccounts.js
@@ -1,9 +1,0 @@
-// Wrap web3.eth.getAccounts in a Promise
-const getAccounts = web3 =>
-  new Promise((resolve, reject) => {
-    web3.eth.getAccounts(
-      (error, accounts) => (error ? reject(error) : resolve(accounts))
-    )
-  })
-
-export default getAccounts

--- a/client/src/utils/getContractInstance.js
+++ b/client/src/utils/getContractInstance.js
@@ -1,21 +1,10 @@
-import getContract from 'truffle-contract'
-
 const getContractInstance = async (web3, contractDefinition) => {
-  const contract = getContract(contractDefinition)
-  contract.setProvider(web3.currentProvider)
+  // get network ID and the deployed address
+  const networkId = await web3.eth.net.getId()
+  const deployedAddress = contractDefinition.networks[networkId].address
 
-  // Dirty hack for web3@1.0.0 support for localhost testrpc.
-  // see https://github.com/trufflesuite/truffle-contract/issues/56#issuecomment-331084530
-  if (typeof contract.currentProvider.sendAsync !== 'function') {
-    contract.currentProvider.sendAsync = function () {
-      return contract.currentProvider.send.apply(
-        contract.currentProvider, arguments
-      )
-    }
-  }
-
-  // Ensure the contract is deployed, and then return the instance.
-  const instance = await contract.deployed()
+  // create the instance
+  const instance = new web3.eth.Contract(contractDefinition.abi, deployedAddress)
   return instance
 }
 


### PR DESCRIPTION
Several things were done here:

1. Removed Truffle-Contract dependency
2. `getAccounts` can now be called directly from the Web3 1.0 API
3. Simplified method of getting contract instance
4. Calling Smart Contract methods is now done the regular Web3 way (instead of the truffle-contract way)